### PR TITLE
updating the index-page to be used with the new header

### DIFF
--- a/src/styles/fossevents.css
+++ b/src/styles/fossevents.css
@@ -379,3 +379,12 @@ table.month p.eventdate {
     margin: 2rem 0;
     text-align: center;
 }
+
+.img-link-center {
+    display: block;
+    text-align: center;
+}
+
+.text-center {
+    text-align: center;
+}

--- a/src/templates/about.html
+++ b/src/templates/about.html
@@ -124,12 +124,14 @@
         happening in Europe</a> on the front-page.
     </p>
 
-    <p>Keep in mind that this page is work in progress. It is build from scratch and step by step shall become a
+    <p>
+        Keep in mind that this page is work in progress. It is build from scratch and step by step shall become a
         database-driven web-project for and by the FOSS community to help connecting people. If you are interested in
         sharing knowlege or improving something <a
-                href="mailto:contact@foss.events">get in contact</a> or open an issue on <a
-                href="https://github.com/foss-events/website">github</a>. Also pass by once in a while on this page to
-        enjoy the newest features : )</p></p>
+            href="mailto:contact@foss.events">get in contact</a> or open an issue on <a
+            href="https://github.com/foss-events/website">github</a>. Also pass by once in a while on this page to enjoy
+        the newest features : )
+    </p>
 
     <a class="nav-to-top" href="about.html#top">Navigation [&uarr;]</a>
 
@@ -363,8 +365,9 @@
     </p>
 
     <a href="https://www.websitecarbon.com/website/foss-events/"><img src="/img/2020-websitecarbonfootprint-300.jpg"
-                                                                      style="display: block; margin: 0 auto;"
-                                                                      alt="Websitecarbon.com says: This website is cleaner than 98% of websites tested"></a>
+                                                                       style="display: block; margin: 0 auto;"
+                                                                       alt="Websitecarbon.com says: This website is cleaner than 98% of websites tested">
+    </a>
 
     <p>Only 0.01g of CO2 is produced every time someone visits this website.</p>
 
@@ -386,7 +389,7 @@
 
     <img src="/img/2020-eff-privacy-badger-400.jpg"
          style="display: block; margin: 0 auto;"
-         alt="Electronic Frontier Foundation's Privadcy Badger says: No trackers detected: Hooray for Privacy"></a>
+         alt="Electronic Frontier Foundation's Privadcy Badger says: No trackers detected: Hooray for Privacy">
 
     <p>
         // foss.events supports <a href="https://degooglisons-internet.org/en/">de-Googlization</a>. Our website is
@@ -396,50 +399,51 @@
 
         <img src="/img/2020-trex-google-free-400.jpg"
              style="display: block; margin: 0 auto;"
-             alt="kreuzberg.google.tracking.exposed says: This site is free from Google trackers!"></a>
-
+             alt="kreuzberg.google.tracking.exposed says: This site is free from Google trackers!">
 
     </p>
 
     <a class="nav-to-top" href="about.html#top">Navigation [&uarr;]</a>
 
-    <section id="contact" class="section">
+</section>
 
-        <h2>about: contact</h2>
+<section id="contact" class="section">
 
-        <p>
-            Whenever you feel like giving us your feedback, you have a good idea or you want to give us a digital hug,
-            you can simply send us an <a href="mailto:contact@foss.events">email</a>. Also consider following us on <a
-                rel="me"
-                href="https://mastodon.social/@FOSS_events">Mastodon</a> or <a href="https://twitter.com/FOSS_events">Twitter</a>
-            to enjoy our toots and tweets around foss-events in Europe.
-        </p>
+    <h2>about: contact</h2>
 
-
-        <h3 id="people">about: people</h3>
-
-        <p>
-            // foss.events is a project for and by all FOSS enthusiasts and everyone else who seeks living in a Free
-            Society. In its daily operations it is run by some friendly Free Software geeks who simply feel like doing
-            what we feel to be good. If you have questions or you look for direct contact, reach out to <a
-                href="https://mastodon.social/@3rik">Erik 'Dreirik' Albers</a> (brainpower), <a
-                href="https://github.com/weeman1337">Michael Weimann</a> (technical lead) or <a
-                href="https://mastodon.social/@mxmehl">Max Mehl</a> (department of good advice).
-        </p>
+    <p>
+        Whenever you feel like giving us your feedback, you have a good idea or you want to give us a digital hug, you
+        can simply send us an <a href="mailto:contact@foss.events">email</a>. Also consider following us on <a
+            rel="me"
+            href="https://mastodon.social/@FOSS_events">Mastodon</a> or <a href="https://twitter.com/FOSS_events">Twitter</a>
+        to enjoy our toots and tweets around foss-events in Europe.
+    </p>
 
 
-        <p>
-            The domain foss.events was initially registered and run by <a href="https://openrheinruhr.de/">OpenRheinRuhr
-            e.V.</a> and later generously shared with // foss.events. Thank you so much for this priceless contribution!
-        </p>
+    <h3 id="people">about: people</h3>
 
-        <a class="nav-to-top" href="about.html#top">Navigation [&uarr;]</a>
+    <p>
+        // foss.events is a project for and by all FOSS enthusiasts and everyone else who seeks living in a Free
+        Society. In its daily operations it is run by some friendly Free Software geeks who simply feel like doing what
+        we feel to be good. If you have questions or you look for direct contact, reach out to <a
+            href="https://mastodon.social/@3rik">Erik 'Dreirik' Albers</a> (brainpower), <a
+            href="https://github.com/weeman1337">Michael Weimann</a> (technical lead) or <a
+            href="https://mastodon.social/@mxmehl">Max Mehl</a> (department of good advice).
+    </p>
 
-    </section>
 
-    <p><a href="/img/imprint.png">Imprint</a></p>
+    <p>
+        The domain foss.events was initially registered and run by <a href="https://openrheinruhr.de/">OpenRheinRuhr
+        e.V.</a> and later generously shared with // foss.events. Thank you so much for this priceless contribution!
+    </p>
 
-    {% include 'partials/footer.html' %}
+    <a class="nav-to-top" href="about.html#top">Navigation [&uarr;]</a>
+
+</section>
+
+<p><a href="/img/imprint.png">Imprint</a></p>
+
+{% include 'partials/footer.html' %}
 
 </body>
 

--- a/src/templates/about.html
+++ b/src/templates/about.html
@@ -61,8 +61,8 @@
         Planet Earth in its late 2010s: Europeans are facing massive right-wing populism with an uprise of right-wing
         movements in most parts of the continent. In just a little of time, nationalist parties and conservative leaders
         are tearing down fundamental freedoms. Freedoms that have taken decades to be introduced and established. We
-        already suffer by new forms of political oppression and restrictions of freedom in many European member states. One can
-        only speculate how the situation develops in the next decade or the one after, how borders and walls
+        already suffer by new forms of political oppression and restrictions of freedom in many European member states.
+        One can only speculate how the situation develops in the next decade or the one after, how borders and walls
         outside and within Europe will be re-established. But one can be sure that when crossing borders will become a
         privilege again, inter-European families, networks, communities and the whole civil society will get dispersed.
     </p>
@@ -120,13 +120,13 @@
     </p>
 
     <p>
-        You find <a href="/">the most comprehensive list of Free, Libre and/or Open Source Software (related) events happening in Europe</a>
-        on the front-page.
+        You find <a href="/">the most comprehensive list of Free, Libre and/or Open Source Software (related) events
+        happening in Europe</a> on the front-page.
     </p>
-    
-    <p>Keep in mind that this page is work in progress. It is build from scratch and step by step shall become a database-driven web-project for and by
-        the FOSS community to help connecting people. If you are interested in sharing knowlege or improving something
-        <a
+
+    <p>Keep in mind that this page is work in progress. It is build from scratch and step by step shall become a
+        database-driven web-project for and by the FOSS community to help connecting people. If you are interested in
+        sharing knowlege or improving something <a
                 href="mailto:contact@foss.events">get in contact</a> or open an issue on <a
                 href="https://github.com/foss-events/website">github</a>. Also pass by once in a while on this page to
         enjoy the newest features : )</p></p>
@@ -136,45 +136,92 @@
 </section>
 
 
-
 <section id="data" class="section">
 
     <h2>about: data</h2>
-    
+
     <p>
-		All event-data on // foss.events is collected by hand or generously shared with us by an event-organiser. In both cases we guarantee neither completeness nor correctness of the data shown. In doubt, please re-assure with the event's own webpage. If you find something is wrong on our page, please help to fix it by contributing [<a href="#contributing">&darr;</a>]. Refer to this legend to understand our data-set:
+        All event-data on // foss.events is collected by hand or generously shared with us by an event-organiser. In
+        both cases we guarantee neither completeness nor correctness of the data shown. In doubt, please re-assure with
+        the event's own webpage. If you find something is wrong on our page, please help to fix it by contributing [<a
+            href="#contributing">&darr;</a>]. Refer to this legend to understand our data-set:
     </p>
-    
+
     <h3 id="legend">about: legend</h3>
-    
+
     <ul>
-		<li>Date, Name, Location (Venue, City, Country) and links to OpenStreetMap, Code of Conduct, Call for Participation: This data is exactly what the relevant label implies.</li>
-		<li>Self-Description: One Sentence up to some paragraphs that are copy and pasted from the event's web-page to describe the event. </li>
-		<li>Type: We differentiate between different kinds of events. So far on our list we have:
-			<ul>
-				<li>Community Conference: A conference about everything FOSS &amp; organised by/for a community, usually includes booths for free by non-profit organisations. Examples: FOSDEM, Froscon, etc.</li>
-				<li>Project Conference: A conference dedicated to a particular project, for example NixOS, OpenSuse etc.</li>
-				<li>Science Conference: A conference about something FOSS, run by/for scientists.</li>
-				<li>Business Conference: A conference organised for/by business, usually includes booths by for-profit organisations for money. Examples: CubeCon, OpenExpo, Linuxplumbet etc.</li>
-				<li>Policy Conference: A conference run by/for administrations, policy, politics. Examples: Connected Smart Cities Conference, Digitale Souveränität, etc.</li>
-				<li>Exhibition: Fair. Sometimes without talks but often mixed with a conference.</li>
-				<li>Hackmeeting: Meetings to come together and hack without conference around and without competition like in a hackathon. Examples: GNU Hackers Meeting, Debcamp etc</li>
-				<li>Hackathon: competitive hack events with winners and awards</li>
-				<li>Camping: FOSS events outdoors with camping on-site.</li>
-				<li>Festival: Events that include or are only about a festival-atmosphere and entertainment.</li>
-				<li>Unconference: FOSS happenings that bring people together in un-organised spontaneous talks and workshops like in unconferences and barcamps.</li>
-				<li>Global Day: Days to celebrate FOSS around the globe. Examples: IloveFS, Software Freedom Day etc.</li>
-				<li>Regional Day: Days to celebrate FOSS in a particular region. For example Flisol, Linux Presentation Day etc</li>
-			</ul>
-		</li>
-		<li>Standard participation fee: Participation fee if you buy a standard ticket without discount, early bird etc.</li>
-		<li>Participants last time: The estimated number of visitors this event happened the last time.</li>
-		<li>Main language: The default language of the talks given, not of the visitors. The main language is English, for example, in case all talks are in English although the visitors speak mainly another (local) language.</li>
-		<li>Specialities: Any speciality. Individual.</li>
+        <li>
+            Date, Name, Location (Venue, City, Country) and links to OpenStreetMap, Code of Conduct, Call for
+            Participation: This data is exactly what the relevant label implies.
+        </li>
+        <li>
+            Self-Description: One Sentence up to some paragraphs that are copy and pasted from the event's web-page to
+            describe the event.
+        </li>
+        <li>
+            Type: We differentiate between different kinds of events. So far on our list we have:
+            <ul>
+                <li>
+                    Community Conference: A conference about everything FOSS &amp; organised by/for a community, usually
+                    includes booths for free by non-profit organisations. Examples: FOSDEM, Froscon, etc.
+                </li>
+                <li>
+                    Project Conference: A conference dedicated to a particular project, for example NixOS, OpenSuse etc.
+                </li>
+                <li>
+                    Science Conference: A conference about something FOSS, run by/for scientists.
+                </li>
+                <li>Business Conference: A conference organised for/by business, usually includes booths by for-profit
+                    organisations for money. Examples: CubeCon, OpenExpo, Linuxplumbet etc.
+                </li>
+                <li>
+                    Policy Conference: A conference run by/for administrations, policy, politics. Examples: Connected
+                    Smart Cities Conference, Digitale Souveränität, etc.
+                </li>
+                <li>
+                    Exhibition: Fair. Sometimes without talks but often mixed with a conference.
+                </li>
+                <li>
+                    Hackmeeting: Meetings to come together and hack without conference around and without competition
+                    like in a hackathon. Examples: GNU Hackers Meeting, Debcamp etc
+                </li>
+                <li>
+                    Hackathon: competitive hack events with winners and awards
+                </li>
+                <li>
+                    Camping: FOSS events outdoors with camping on-site.
+                </li>
+                <li>
+                    Festival: Events that include or are only about a festival-atmosphere and entertainment.
+                </li>
+                <li>
+                    Unconference: FOSS happenings that bring people together in un-organised spontaneous talks and
+                    workshops like in unconferences and barcamps.
+                </li>
+                <li>
+                    Global Day: Days to celebrate FOSS around the globe. Examples: IloveFS, Software Freedom Day etc.
+                </li>
+                <li>
+                    Regional Day: Days to celebrate FOSS in a particular region. For example Flisol, Linux Presentation
+                    Day etc
+                </li>
+            </ul>
+        </li>
+        <li>
+            Standard participation fee: Participation fee if you buy a standard ticket without discount, early bird etc.
+        </li>
+        <li>
+            Participants last time: The estimated number of visitors this event happened the last time.
+        </li>
+        <li>
+            Main language: The default language of the talks given, not of the visitors. The main language is English,
+            for example, in case all talks are in English although the visitors speak mainly another (local) language.
+        </li>
+        <li>
+            Specialities: Any speciality. Individual.
+        </li>
     </ul>
-    
     <a class="nav-to-top" href="about.html#top">Navigation [&uarr;]</a>
-    
 </section>
 
 
@@ -206,25 +253,25 @@
 </section>
 
 
-
 <section id="contributing" class="section">
 
     <h2>about: contributing</h2>
     <p>
         If you know of an event that matches our criteria [<a href="#criteria">&darr;</a>] and you do not see it
-        mentioned in our list of events, please contribute. The easiest option is to simply copy-paste the URL of the event
-        into the body section of <a
-            href="mailto:onemore@foss.events?subject=one more event">an email</a> and after checking we will list it here.
-        Also if you see that some information is missing on our side, use <a
-            href="mailto:thesameemailaddress@foss.events?subject=one more event">the same email-address</a> and send us any missing
-        information of the event.
+        mentioned in our list of events, please contribute. The easiest option is to simply copy-paste the URL of the
+        event into the body section of <a
+            href="mailto:onemore@foss.events?subject=one more event">an email</a> and after checking we will list it
+        here. Also if you see that some information is missing on our side, use <a
+            href="mailto:thesameemailaddress@foss.events?subject=one more event">the same email-address</a> and send us
+        any missing information of the event.
     </p>
 
     <p>
         If you are an organiser or you have 5 minutes of time, it would be of such a great help to this project if you
         can <a
             href="mailto:onemore@foss.events?subject=one more event&body=Hi all,%0D%0A%0D%0Aplease add/update this event on // foss.events:%0D%0A%0D%0AName:%0D%0ADate:%0D%0AURL:%0D%0AShortname:%0D%0AHashtag:%0D%0ACity:%0D%0ACountry:%0D%0AVenue:%0D%0AOSM-Link:%0D%0ASelf-Description:%0D%0ALink for Call for Participation:%0D%0ADeadline for Call for Participation:%0D%0ALink for Code of Conduct:%0D%0AEntrance Fee:%0D%0ARegistration required:%0D%0AParticipants last time:%0D%0AMain language:%0D%0AAny specialties: ">use
-        this advanced email-template</a> and help us with collecting all necessary information about an event. If you have trouble understand our data-set, check the legend <a href="#legend">[&uarr;]</a> for an explanation.
+        this advanced email-template</a> and help us with collecting all necessary information about an event. If you
+        have trouble understand our data-set, check the legend <a href="#legend">[&uarr;]</a> for an explanation.
     </p>
 
     <h3 style="text-align:center">Thank you so much for your contribution!</h3>
@@ -234,8 +281,6 @@
     <a class="nav-to-top" href="about.html#top">Navigation [&uarr;]</a>
 
 </section>
-
-
 
 
 <!--
@@ -264,13 +309,13 @@
 -->
 
 <section id="freedom" class="section">
-	
-	<h2>about: freedom</h2>
+
+    <h2>about: freedom</h2>
 
     <p>
         We believe in the 4 freedoms to use, study, share and improve an software. Our page is self-made and published
-        as FOSS under <a href="https://www.gnu.org/licenses/agpl-3.0.html">AGPLv3</a>. You can <a href="">find
-        the code on github</a>.
+        as FOSS under <a href="https://www.gnu.org/licenses/agpl-3.0.html">AGPLv3</a>. You can <a href="">find the code
+        on github</a>.
     </p>
 
 
@@ -278,19 +323,20 @@
 
     <p>
         There are reasons and arguments why some people prefer FOSS over FLOSS or vice versa, why some refer to Open
-        Source and others to Free Software or Libre Software. And who knows, potentially in the next decade even a new term will be created ... (We heard sustainable
-        software is an upcoming candidate.)
+        Source and others to Free Software or Libre Software. And who knows, potentially in the next decade even a new
+        term will be created ... (We heard sustainable software is an upcoming candidate.)
     </p>
-        
+
     <p>
         At // foss.events we love this diversity. All these terms have their relevance and they allow us to put slightly
-        different emphasis on the same technologies. Because apart from the actual naming and the details in the semantics, all these names technically refer to the
-        same kind of software: Software that is published under a license that grants any user the 4 freedoms to use, study,
-        share and improve the software without limitations. That is why on // foss.events we will not prefer one name
-        over the other and in case we use one, it is representative to all the others.</p> 
-        
-	<p> Let us unite in diversity: <strong>No matter the name, if your event
-        is about the four freedoms of software your event is part of // foss.events!</strong>
+        different emphasis on the same technologies. Because apart from the actual naming and the details in the
+        semantics, all these names technically refer to the same kind of software: Software that is published under a
+        license that grants any user the 4 freedoms to use, study, share and improve the software without limitations.
+        That is why on // foss.events we will not prefer one name over the other and in case we use one, it is
+        representative to all the others.</p>
+
+    <p> Let us unite in diversity: <strong>No matter the name, if your event is about the four freedoms of software your
+        event is part of // foss.events!</strong>
     </p>
 
     <a class="nav-to-top" href="about.html#top">Navigation [&uarr;]</a>
@@ -317,8 +363,8 @@
     </p>
 
     <a href="https://www.websitecarbon.com/website/foss-events/"><img src="/img/2020-websitecarbonfootprint-300.jpg"
-				  style="display: block; margin: 0 auto;"
-				  alt="Websitecarbon.com says: This website is cleaner than 98% of websites tested"></a>
+                                                                      style="display: block; margin: 0 auto;"
+                                                                      alt="Websitecarbon.com says: This website is cleaner than 98% of websites tested"></a>
 
     <p>Only 0.01g of CO2 is produced every time someone visits this website.</p>
 
@@ -328,71 +374,72 @@
 
 
 <section id="privacy" class="section">
-	
-	<h2>about: privacy</h2>
-	
-	<p>
-		// foss.events does not track you. We do not collect any data or behaviour on our sites. The Electronic Frontiers Foundation's <a href="https://www.eff.org/privacybadger">Privacy Badge</a> gives us a Hooray for Privacy:
-		
-	</p>
-	
-	<img src="/img/2020-eff-privacy-badger-400.jpg"
-		  style="display: block; margin: 0 auto;"
-		  alt="Electronic Frontier Foundation's Privadcy Badger says: No trackers detected: Hooray for Privacy"></a>
 
-	<p>
-		// foss.events supports <a href="https://degooglisons-internet.org/en/">de-Googlization</a>. Our website is self-coded [<a href="#freedom">&uarr;</a>] and we do not use Google for nothing! <a href="https://kreuzberg.google.tracking.exposed/">Google tracking exposed</a> confirms: No analysis, no trackers, no ads.
-		
-	<img src="/img/2020-trex-google-free-400.jpg"
-		  style="display: block; margin: 0 auto;"
-		  alt="kreuzberg.google.tracking.exposed says: This site is free from Google trackers!"></a> 
-	
-	
-	</p>
-	
-	    <a class="nav-to-top" href="about.html#top">Navigation [&uarr;]</a>
-
-
-
-
-<section id="contact" class="section">
-
-    <h2>about: contact</h2>
+    <h2>about: privacy</h2>
 
     <p>
-        Whenever you feel like giving us your feedback, you have a good idea or you want to give us a digital hug, you
-        can simply send us an <a href="mailto:contact@foss.events">email</a>. Also consider following us on <a rel="me"
-                                                                                                               href="https://mastodon.social/@FOSS_events">Mastodon</a>
-        or <a href="https://twitter.com/FOSS_events">Twitter</a> to enjoy our toots and tweets around foss-events in
-        Europe.
+        // foss.events does not track you. We do not collect any data or behaviour on our sites. The Electronic
+        Frontiers Foundation's <a href="https://www.eff.org/privacybadger">Privacy Badge</a> gives us a Hooray for
+        Privacy:
+
     </p>
 
-
-
-    <h3 id="people">about: people</h3>
-
-    <p>
-        // foss.events is a project for and by all FOSS enthusiasts and everyone else who seeks living in a Free
-        Society. In its daily operations it is run by some friendly Free Software geeks who simply feel like doing what
-        we feel to be good. If you have questions or you look for direct contact, reach out to <a href="https://mastodon.social/@3rik">Erik
-        'Dreirik' Albers</a> (brainpower), <a href="https://github.com/weeman1337">Michael Weimann</a> (technical lead) or <a href="https://mastodon.social/@mxmehl">Max Mehl</a> (department of good advice).
-    </p>
-    
-
-  
+    <img src="/img/2020-eff-privacy-badger-400.jpg"
+         style="display: block; margin: 0 auto;"
+         alt="Electronic Frontier Foundation's Privadcy Badger says: No trackers detected: Hooray for Privacy"></a>
 
     <p>
-        The domain foss.events was initially registered and run by <a href="https://openrheinruhr.de/">OpenRheinRuhr
-        e.V.</a> and later generously shared with // foss.events. Thank you so much for this priceless contribution!
+        // foss.events supports <a href="https://degooglisons-internet.org/en/">de-Googlization</a>. Our website is
+        self-coded [<a href="#freedom">&uarr;</a>] and we do not use Google for nothing! <a
+            href="https://kreuzberg.google.tracking.exposed/">Google tracking exposed</a> confirms: No analysis, no
+        trackers, no ads.
+
+        <img src="/img/2020-trex-google-free-400.jpg"
+             style="display: block; margin: 0 auto;"
+             alt="kreuzberg.google.tracking.exposed says: This site is free from Google trackers!"></a>
+
+
     </p>
 
     <a class="nav-to-top" href="about.html#top">Navigation [&uarr;]</a>
 
-</section>
+    <section id="contact" class="section">
 
-<p><a href="/img/imprint.png">Imprint</a></p>
+        <h2>about: contact</h2>
 
-{% include 'partials/footer.html' %}
+        <p>
+            Whenever you feel like giving us your feedback, you have a good idea or you want to give us a digital hug,
+            you can simply send us an <a href="mailto:contact@foss.events">email</a>. Also consider following us on <a
+                rel="me"
+                href="https://mastodon.social/@FOSS_events">Mastodon</a> or <a href="https://twitter.com/FOSS_events">Twitter</a>
+            to enjoy our toots and tweets around foss-events in Europe.
+        </p>
+
+
+        <h3 id="people">about: people</h3>
+
+        <p>
+            // foss.events is a project for and by all FOSS enthusiasts and everyone else who seeks living in a Free
+            Society. In its daily operations it is run by some friendly Free Software geeks who simply feel like doing
+            what we feel to be good. If you have questions or you look for direct contact, reach out to <a
+                href="https://mastodon.social/@3rik">Erik 'Dreirik' Albers</a> (brainpower), <a
+                href="https://github.com/weeman1337">Michael Weimann</a> (technical lead) or <a
+                href="https://mastodon.social/@mxmehl">Max Mehl</a> (department of good advice).
+        </p>
+
+
+        <p>
+            The domain foss.events was initially registered and run by <a href="https://openrheinruhr.de/">OpenRheinRuhr
+            e.V.</a> and later generously shared with // foss.events. Thank you so much for this priceless contribution!
+        </p>
+
+        <a class="nav-to-top" href="about.html#top">Navigation [&uarr;]</a>
+
+    </section>
+
+    <p><a href="/img/imprint.png">Imprint</a></p>
+
+    {% include 'partials/footer.html' %}
 
 </body>
 

--- a/src/templates/about.html
+++ b/src/templates/about.html
@@ -2,7 +2,7 @@
 <html lang="en">
 
 <head>
-    <base href="/about">
+    <base href="/about.html">
 
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta charset="UTF-8">
@@ -90,7 +90,6 @@
 </section>
 
 <section class="section">
-
     <div class="stickercontainer">
         <div class="stickercontainer__sticker">
             <h3>No borders. No nations.</h3>
@@ -106,12 +105,10 @@
     </div>
 
     <a class="nav-to-top" href="about.html#top">Navigation [&uarr;]</a>
-
 </section>
 
 
 <section id="website" class="section">
-
     <h2>about: website</h2>
 
     <p>
@@ -134,12 +131,10 @@
     </p>
 
     <a class="nav-to-top" href="about.html#top">Navigation [&uarr;]</a>
-
 </section>
 
 
 <section id="data" class="section">
-
     <h2>about: data</h2>
 
     <p>
@@ -226,9 +221,7 @@
     <a class="nav-to-top" href="about.html#top">Navigation [&uarr;]</a>
 </section>
 
-
 <section id="criteria" class="section">
-
     <h2>about: criteria</h2>
 
     <p>
@@ -251,12 +244,10 @@
         yet in our list, please contribute. [<a href="#contribute">&uarr;</a>]</p>
 
     <a class="nav-to-top" href="about.html#top">Navigation [&uarr;]</a>
-
 </section>
 
 
 <section id="contributing" class="section">
-
     <h2>about: contributing</h2>
     <p>
         If you know of an event that matches our criteria [<a href="#criteria">&darr;</a>] and you do not see it
@@ -281,7 +272,6 @@
     <div class="heart">♥</div>
 
     <a class="nav-to-top" href="about.html#top">Navigation [&uarr;]</a>
-
 </section>
 
 
@@ -311,7 +301,6 @@
 -->
 
 <section id="freedom" class="section">
-
     <h2>about: freedom</h2>
 
     <p>
@@ -342,11 +331,9 @@
     </p>
 
     <a class="nav-to-top" href="about.html#top">Navigation [&uarr;]</a>
-
 </section>
 
 <section id="sustainability" class="section">
-
     <h2>about: sustainability</h2>
 
     <p>
@@ -354,9 +341,9 @@
         Green Web Foundation</a>:
     </p>
 
-    <a href="https://www.thegreenwebfoundation.org/green-web-check/?url=foss.events"><img
+    <a href="https://www.thegreenwebfoundation.org/green-web-check/?url=foss.events"
+       class="img-link-center"> <img
             src="https://api.thegreenwebfoundation.org/greencheckimage/foss.events"
-            style="display: block; margin: 0 auto;"
             alt="This website is hosted Green - checked by thegreenwebfoundation.org"></a>
 
     <p>
@@ -364,47 +351,45 @@
             href="https://www.websitecarbon.com/website/foss-events/">is cleaner than 98% of websites tested</a> \°/
     </p>
 
-    <a href="https://www.websitecarbon.com/website/foss-events/"><img src="/img/2020-websitecarbonfootprint-300.jpg"
-                                                                       style="display: block; margin: 0 auto;"
-                                                                       alt="Websitecarbon.com says: This website is cleaner than 98% of websites tested">
-    </a>
+    <a
+            href="https://www.websitecarbon.com/website/foss-events/"
+            class="img-link-center"> <img
+            src="/img/2020-websitecarbonfootprint-300.jpg"
+            alt="Websitecarbon.com says: This website is cleaner than 98% of websites tested"> </a>
 
     <p>Only 0.01g of CO2 is produced every time someone visits this website.</p>
 
     <a class="nav-to-top" href="about.html#top">Navigation [&uarr;]</a>
-
 </section>
 
-
 <section id="privacy" class="section">
-
     <h2>about: privacy</h2>
 
     <p>
         // foss.events does not track you. We do not collect any data or behaviour on our sites. The Electronic
         Frontiers Foundation's <a href="https://www.eff.org/privacybadger">Privacy Badge</a> gives us a Hooray for
         Privacy:
-
     </p>
 
-    <img src="/img/2020-eff-privacy-badger-400.jpg"
-         style="display: block; margin: 0 auto;"
-         alt="Electronic Frontier Foundation's Privadcy Badger says: No trackers detected: Hooray for Privacy">
+    <div class="text-center">
+        <img src="/img/2020-eff-privacy-badger-400.jpg"
+             alt="Electronic Frontier Foundation's Privadcy Badger says: No trackers detected: Hooray for Privacy">
+    </div>
 
     <p>
         // foss.events supports <a href="https://degooglisons-internet.org/en/">de-Googlization</a>. Our website is
         self-coded [<a href="#freedom">&uarr;</a>] and we do not use Google for nothing! <a
             href="https://kreuzberg.google.tracking.exposed/">Google tracking exposed</a> confirms: No analysis, no
         trackers, no ads.
-
-        <img src="/img/2020-trex-google-free-400.jpg"
-             style="display: block; margin: 0 auto;"
-             alt="kreuzberg.google.tracking.exposed says: This site is free from Google trackers!">
-
     </p>
 
-    <a class="nav-to-top" href="about.html#top">Navigation [&uarr;]</a>
+    <div class="text-center">
+        <img src="/img/2020-trex-google-free-400.jpg"
+             class="img img--center"
+             alt="kreuzberg.google.tracking.exposed says: This site is free from Google trackers!">
+    </div>
 
+    <a class="nav-to-top" href="about.html#top">Navigation [&uarr;]</a>
 </section>
 
 <section id="contact" class="section">

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -37,7 +37,6 @@
 
 {% include 'partials/header-logo.html' %}
 
-
 <p>
     This page is <a href="/about.html">about</a> connecting people beyond borders
     and nations who understand the benefits of sharing knowledge and to
@@ -52,8 +51,6 @@
     <a href="/about.html#diversity">Unity in diversity!</a>
 </p>
 
-
-
 {% if has_upcoming %}
 
 	<h1 id="fossevents" class="topheading">FOSS events in Europe</h1>
@@ -64,8 +61,6 @@
     <h2 id="upcoming" style="text-align:center; margin-bottom: 2em;">
         Upcoming in {{ year }}
     </h2>
-
-    
 
     {% for month_id, month in upcoming.items() %}
         {% if month['events'] %}
@@ -90,14 +85,12 @@
 
 {% endif %}
 
-
 <p>
     If you know about an event that is not yet listed here and it
     matches the <a href="/about.html#criteria">criteria</a>,
     please <a href="/about.html#contribute">contribute</a>.
     For any questions get in <a href="/about.html#contact">contact</a>.
 </p>
-
 
 {% if has_prev %}
     <h2 id="passed" class="topheading">

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -37,20 +37,9 @@
 
 {% include 'partials/header-logo.html' %}
 
-<p class="navlinks">
-    {% if year == '2019' %}
-        <span class="navlinks__link navlinks__link--active">2019</span>
-        <span class="navlinks__separator">|</span>
-        <a href="/" class="navlinks__link navlinks__link--inactive">2020</a>
-    {% else %}
-        <a href="/2019" class="navlinks__link navlinks__link--inactive">2019</a>
-        <span class="navlinks__separator">|</span>
-        <span class="navlinks__link navlinks__link--active">2020</span>
-    {% endif %}
-</p>
 
 <p>
-    This page is <a href="#about">about</a> connecting people beyond borders
+    This page is <a href="/about.html">about</a> connecting people beyond borders
     and nations who understand the benefits of sharing knowledge and to
     collectively use, study, share and improve it for everyone.
 </p>
@@ -58,27 +47,25 @@
 <p>
     You find a list of Free, Libre and/or Open Source Software (related)
     events happening in Europe in {{ year }}
-    below, chronologically sorted into <a href="#upcoming">upcoming</a>
+    below, chronologically sorted into <a href="#fossevents">upcoming</a>
     and <a href="#passed">passed</a>.
-    Unity in diversity!
+    <a href="/about.html#diversity">Unity in diversity!</a>
 </p>
 
-<p>
-    If you know about an event that is not yet listed here and it
-    matches the <a href="#criteria">criteria</a>,
-    please <a href="#contribute">contribute</a>.
-    For any questions get in <a href="#contact">contact</a>.
-</p>
+
 
 {% if has_upcoming %}
 
-    <h1 id="upcoming" class="topheading">
-        Upcoming events in {{ year }}
-    </h1>
-
-    <div class="topheading__divider" style="padding: 0 40% 0 40%">
+	<h1 id="fossevents" class="topheading">FOSS events in Europe</h1>
+	<div style="padding: 0 40% 0 40%">
         <hr>
     </div>
+
+    <h2 id="upcoming" style="text-align:center; margin-bottom: 2em;">
+        Upcoming in {{ year }}
+    </h2>
+
+    
 
     {% for month_id, month in upcoming.items() %}
         {% if month['events'] %}
@@ -103,10 +90,19 @@
 
 {% endif %}
 
+
+<p>
+    If you know about an event that is not yet listed here and it
+    matches the <a href="/about.html#criteria">criteria</a>,
+    please <a href="/about.html#contribute">contribute</a>.
+    For any questions get in <a href="/about.html#contact">contact</a>.
+</p>
+
+
 {% if has_prev %}
-    <h1 id="passed" class="topheading">
+    <h2 id="passed" class="topheading">
         Past events in {{ year }}
-    </h1>
+    </h2>
     <div style="padding: 0 40% 0 40%">
         <hr>
     </div>
@@ -134,141 +130,24 @@
 {% endif %}
 
 
-<h1 id="about" class="topheading">About</h1>
-<div style="padding: 0 40% 3em 40%">
-    <hr>
-</div>
-
-<div>
-    <p>
-        Planet Earth in its late 2010s: Europeans are facing an uprise of right-wing movements in most parts of the
-        continent. New forms of political oppression and restrictions of freedom are put into practice, creating new
-        deportation procedures, excessive police laws and border controls, new walls and entry bans. One can only
-        speculate how the overall situation will develop in the next decade or the one after, how borders outside and
-        within Europe will be re-established and potentially closed down ... But one can be sure that when crossing
-        borders will become a privilege again, inter-European families, networks and communities will get dispersed.
-    </p>
-
-    <p>
-        To grow and live (in) a free society we need freedom of exchange. We need human cooperation as a breeding ground
-        for creativity and inspiration as well as a fundament to safeguard our peace and mutual understanding. Freedom
-        of people - just as freedom of code - is fundamental to Free, Libre and Open Source Software and their
-        communities and a requirement to collectively construct our commons.
-    </p>
-</div>
-
-<p>This project shall help growing a free society. As long as inner-European borders can still be crossed and
-    international events are possible, this page is here to encourage you to get to know and network with each other.
-    Create international organisations, form resilient communities and build friendships with each other across borders.
-    Go to a FOSS event in another country this year, an event where you have never been before. Get to know new people
-    there, their habits, knowledge and backgrounds. Help each other and listen to each other. And above all do what you
-    always love to do: </p>
-
-<p style="text-align:center">
-    <strong>Use, study, share and improve. Together.</strong>
-</p>
-
-
-<div style="clear: both; padding-top:2em;"></div>
-
-<div class="stickercontainer">
-    <div class="stickercontainer__sticker">
-        <h3>No borders. No nations.</h3>
-        <h3>Just humans.</h3>
-        <h3>And tech.</h3>
+	<h1 id="archive" class="topheading">
+        Archive
+    </h1>
+    <div style="padding: 0 40% 0 40%">
+        <hr>
     </div>
 
-    <div class="stickercontainer__sticker">
-        <h3>No DRM. No firewalls.</h3>
-        <h3>Just freedom.</h3>
-        <h3>And humans.</h3>
-    </div>
+<p>See the list of Free, Libre and/or Open Source Software (related) events happening in Europe in ...</p>
+
+<p style="font-size:200%">
+   
+  <a href="/2019"><strong>2019</strong></a>
+        
+</p>
+
+<div class="footer">
+    Made with <span class="footer__heart">♥</span> | <a href="/about.html">about</a> | <a href="/about.html#contact">contact</a>
 </div>
-
-<a class="nav-to-top" href="#top">Navigation [&uarr;]</a>
-
-
-<h2 class="navhead" id="contribute">about: contribute</h2>
-<p>
-    If you know of an event that matches our criteria [<a href="#criteria">&darr;</a>] and
-    you do not see it mentioned in our list of events [<a href="listofevents">&uarr;</a>],
-    please <a href="mailto:onemore@foss.events?subject=one more event">contribute with an email</a>.
-    Easiest option is to simply copy-paste the URL of the event into the body section of your mail and
-    after checking we will list it here. If you see that some information is missing on our side, use the same
-    email-address and send us the missing information.
-</p>
-
-
-<p>
-    If you are an organiser or you have 5 minutes of time, it would be of such a great help to this project if you can
-    <a href="mailto:onemore@foss.events?subject=one more event&body=Hi all,%0D%0A%0D%0Aplease add/update this event on // foss.events:%0D%0A%0D%0AName:%0D%0ADate:%0D%0AURL:%0D%0ACity:%0D%0ACountry:%0D%0AOSM-Link:%0D%0ASelf-Description:%0D%0ALink for Call for Participation:%0D%0ADeadline for Call for Participation:%0D%0ALink for Code of Conduct:%0D%0AEntrance Fee:%0D%0AParticipants last time:%0D%0AMain language: ">use
-        this advanced email-template</a> and help us with collecting all necessary information about an event.
-</p>
-
-<h3 style="text-align:center">Thank you so much for your contribution!</h3>
-<div class="heart">♥</div>
-<a class="nav-to-top" href="#top">Navigation [&uarr;]</a>
-
-<h2 class="navhead" id="criteria">about: criteria</h2>
-
-<p>
-    // foss.events is all about collecting and spreading FOSS events in Europe. These are mainly conferences but can
-    also be meetings, *-a-thons, camps, festival, exhibitions and other kind of events - as long as they match the
-    following criteria:
-</p>
-
-<ul>
-    <li>only events that happen in Europe.</li>
-    <li>only events that are open for the general public. Entrance fee is ok, but events shall be accessible for
-        everyone to participate and in particular not restricted to a specific group like the members of a specific
-        group, organisation or similar.
-    </li>
-    <li>only "full-day" events. As a rule of thumb, that means events that are at least 6-8 hours or more.</li>
-</ul>
-
-
-<p>If you know about Free, Libre and/or Open Source Software event in Europe that matches this criteria and is not yet
-    in our list, please contribute [<a href="#contribute">&uarr;</a>]</p>
-
-<a class="nav-to-top" href="#top">Navigation [&uarr;]</a>
-
-
-<h2 class="navhead" id="features">about: features</h2>
-
-<p>This page is work in progress. It is build from scratch and shall become a database-driven web-project for and by the
-    FOSS community to help connecting people. If you are interested in sharing knowlege or improving something <a
-            href="mailto:contact@foss.events">get in contact</a> or open an issue on <a
-            href="https://github.com/foss-events/website">github</a>.
-    Also pass by once in a while on this page to enjoy the newest features : )</p>
-
-<h2 class="navhead" id="contact">about: contact</h2>
-
-<p>
-    Whenever you feel like giving us your feedback, you have a good idea or you want to give us a digital hug, you can
-    simply send us an <a href="mailto:contact@foss.events">email</a>. Also consider following us on
-    <a rel="me" href="https://mastodon.social/@FOSS_events">Mastodon</a>
-    or <a href="https://twitter.com/FOSS_events">Twitter</a> to enjoy our toots and tweets around foss-events in
-    Europe<a rel="me" href="https://mastodon.social/@3rik">.</a>
-</p>
-
-<h2 class="navhead" id="people">about: people</h2>
-
-<p>
-    // foss.events is a project for and by all FOSS enthusiasts and everyone else who seeks
-    living in a Free Society. In its daily operations it is run by some friendly Free Software
-    geeks who simply feel like doing what we feel to be good. No commercial interest involved.
-    Project lead is <a href="https://mastodon.social/@3rik">Erik Albers</a>, technical lead
-    is <a href="https://github.com/weeman1337">Michael Weimann</a>.</p>
-
-<p>The domain foss.events was initially registered and run by
-    <a href="https://openrheinruhr.de/">OpenRheinRuhr e.V.</a> and later generously shared with
-    // foss.events. Thank you so much for this priceless contribution!</p>
-
-<p><a href="/img/imprint.png">Imprint</a>.</p>
-
-<a class="nav-to-top" href="#top">Navigation [&uarr;]</a>
-
-{% include 'partials/footer.html' %}
 
 </body>
 

--- a/src/templates/partials/contribute-box.html
+++ b/src/templates/partials/contribute-box.html
@@ -2,6 +2,6 @@
     <div class="contribute-box__content">
         <h3>missing an event?</h3>
         <h3>info out of date?</h3>
-        <h3>please <a href="/#contribute">contribute</a></h3>
+        <h3>please help to <a href="/about.html#contributing">fix it</a></h3>
     </div>
 </div>


### PR DESCRIPTION
this is the start of the new index-page that should be used with the new header. As the about-page is anyway linked from the top-paragraph + from the footer it can already be merged before the header. However, I leave it for a second look.