### PR TITLE
add fediverse to event pages

### DIFF
--- a/generator/parser.py
+++ b/generator/parser.py
@@ -148,6 +148,11 @@ def parse_event(row, today):
     else:
         participants = '?'
 
+    if row.get('Mastodon', '').startswith('http'):
+        mastodon = row.get('Mastodon')
+    else:
+        mastodon = None
+
     try:
         lat = float(row['lat'])
         lon = float(row['lon'])
@@ -209,7 +214,8 @@ def parse_event(row, today):
         'tags': row.get('tags', None),
         'tech_in_use': row.get('Technologies in use', None),
         'interactivity': row.get('Online Interactivity', None),
-        'technical_liberties': row.get('Technical Liberties', None)
+        'technical_liberties': row.get('Technical Liberties', None),
+        'mastodon': mastodon
     }
 
     event['ical_path'] = generate_event_ical_path(event)

--- a/src/styles/fossevents.css
+++ b/src/styles/fossevents.css
@@ -646,6 +646,10 @@ table.month p.eventdate {
     width: 100%;
 }
 
+.fedifeed--event {
+    margin-bottom: 2rem;
+}
+
 .icon {
     background-position: center center;
     background-repeat: no-repeat;

--- a/src/templates/event.html
+++ b/src/templates/event.html
@@ -38,7 +38,7 @@
     <script defer data-domain="foss.events" src="https://plausible.io/js/plausible.js"></script>
 
     <script async defer data-website-id="393f9149-34ad-4d2f-a2f3-9d3760baceec" src="https://traffic.vioffice.de/umami.js"></script>
-    
+
 
     <title>All about {{ event['label'] }} {{ event['start_year'] }} in a nutshell on // foss.events</title>
 </head>
@@ -309,6 +309,15 @@
     		<div id="map" class="event__map"></div>
 		{% endif %}
 
+    {% if event['mastodon'] %}
+        <div class="h1-divider"></div>
+        <iframe
+                class="fedifeed fedifeed--event"
+                allowfullscreen
+                sandbox="allow-top-navigation allow-scripts"
+                src="https://fedifeed.foss.events/apiv2/feed?userurl={{ event['mastodon'] | urlencode }}&theme=light&size=100&header=false&replies=false&boosts=false">
+        </iframe>
+    {% endif %}
 
 <!-- the contribute-element -->
 


### PR DESCRIPTION
If there is a value in `Mastodon` for any event the feed will be displayed on the details page :tada: You could test that with the Chemnitzer Linux Tage.